### PR TITLE
fix: clear C++20 warning of deprecated implicit capture of this using default capture by copy

### DIFF
--- a/Release/include/pplx/pplxtasks.h
+++ b/Release/include/pplx/pplxtasks.h
@@ -2514,7 +2514,7 @@ struct _Task_impl : public _Task_impl_base
             if (_M_Continuations)
             {
                 // Scheduling cancellation with automatic inlining.
-                _ScheduleFuncWithAutoInline([=]() { _RunTaskContinuations(); }, details::_DefaultAutoInline);
+                _ScheduleFuncWithAutoInline([this]() { _RunTaskContinuations(); }, details::_DefaultAutoInline);
             }
         }
         return true;


### PR DESCRIPTION
The implicit capture of `this` by reference using default capture by copy (`[=]`) is deprecated behaviour under C++20, and should be explicitly specified (`[=, this]`), except this lambda doesn't even need any other variables, so we can just use `[this]` and sidestep the issue altogether.